### PR TITLE
Fix dynamic title and add HTML5 DOCTYPE

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,15 @@
+<!DOCTYPE html>
 <html lang='en'>
   <head>
     <meta charset='UTF-8' />
     <meta name='apple-mobile-web-app-title' content='Happy Valentines Day' />
 
-    <title>From $(hostname -f)</title>
+    <title>Happy Valentines Day</title>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        document.title = 'From ' + window.location.hostname;
+      });
+    </script>
 
     <link
       rel='stylesheet'


### PR DESCRIPTION
## Summary
- add missing HTML5 doctype
- replace shell substitution in title with dynamic hostname script

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - can't access registry)*
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68901dc8bc088320982f19b530bea1e6